### PR TITLE
Fix some compilation errors

### DIFF
--- a/include/EUTelProcessorAnalysisPALPIDEfs.h
+++ b/include/EUTelProcessorAnalysisPALPIDEfs.h
@@ -70,6 +70,8 @@ protected:
   std::string _hotPixelCollectionName;
   std::string _deadColumnCollectionName;
   std::string _noiseMaskFileName;
+  std::vector<float> _holesizeX;
+  std::vector<float> _holesizeY;
   double limit;
   int _dutID;
   int _maxNumberOfPixels;

--- a/src/EUTelProcessorAnalysisPALPIDEfs.cc
+++ b/src/EUTelProcessorAnalysisPALPIDEfs.cc
@@ -57,6 +57,8 @@ EUTelProcessorAnalysisPALPIDEfs::EUTelProcessorAnalysisPALPIDEfs()
   _outputSettingsFolderName("./"),
   _chipID(),
   _irradiation(),
+  _holesizeX(),
+  _holesizeY(),
   _rate(""),
   _oneAlignmentCollection(false),
   _clusterAvailable(true),


### PR DESCRIPTION
Hi HyeonJoong,

during the compilation of test beam software I came across some bugs in EUTelProcessorAnalysisPALPIDEfs.cc and EUTelProcessorAnalysisPALPIDEfs.h.
After the correction (and onother in eudaq I will report soon) I managed to compile everything.

Cheers,
Luca
